### PR TITLE
Adding support for optionally enabling passenger in the default configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 passenger_server_name: www.example.com
 passenger_app_root: /opt/example/public
 passenger_app_env: production
+passenger_enabled: 'on'
 
 passenger_root: /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini
 passenger_ruby: /usr/bin/ruby

--- a/templates/passenger.j2
+++ b/templates/passenger.j2
@@ -1,7 +1,7 @@
 server {
   listen 80 default_server;
   server_name {{ passenger_server_name }};
-  passenger_enabled on;
+  passenger_enabled {{ passenger_enabled }};
   passenger_app_env {{ passenger_app_env }};
   root {{ passenger_app_root }};
 }


### PR DESCRIPTION
This is for a situation in which you may want to disable passenger, yet keep the rest of the configuration, for example, when implementing custom nginx configurations from a separate role.